### PR TITLE
Upgrade base to core24

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,13 +1,17 @@
 name: matterbridge
 version: "v1.26.0"
 summary: MatterBridge protocol bridge
-base: core20
+base: core24
 description: |
   bridge between mattermost, IRC, gitter, xmpp, slack, discord, telegram,
   rocket.chat, hipchat (via xmpp), steam and matrix with REST API
 
 grade: stable
 confinement: strict
+
+platforms:
+  amd64:
+  arm64:
 
 apps:
   matterbridge:
@@ -24,12 +28,12 @@ parts:
       - gcc
     source: https://github.com/42wim/matterbridge.git
     override-pull: |
-      snapcraftctl pull
-      last_committed_tag="$(git describe --tags `git rev-list --tags --max-count=1`)"
+      craftctl default
+      last_committed_tag="$(git describe --tags $(git rev-list --tags --max-count=1))"
       last_committed_tag_ver="$(echo $last_committed_tag)"
-      last_released_tag="$(snap info $SNAPCRAFT_PROJECT_NAME | awk '$1 == "latest/beta:" { print $2 }')"
+      last_released_tag="$(snap info $CRAFT_PROJECT_NAME | awk '$1 == "latest/beta:" { print $2 }')"
       # If the latest tag from the upstream project has not been released to
-      # beta, build that tag instead of master.
+      # beta, build that tag instead of main.
       if [ "${last_committed_tag}" != "${last_released_tag}" ]; then
         git fetch
         git checkout "${last_committed_tag}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,6 +24,8 @@ apps:
 parts:
   matterbridge:
     plugin: go
+    build-snaps:
+      - go/latest/stable
     build-packages:
       - gcc
     source: https://github.com/42wim/matterbridge.git


### PR DESCRIPTION
## Summary

- Upgrade base from `core20` to `core24`
- `architectures:` -> `platforms:`
- `snapcraftctl` -> `craftctl`
- `SNAPCRAFT_*` -> `CRAFT_*` variables
- Update package names for Ubuntu 24.04

## Test plan

- [ ] Verify snap builds successfully
- [ ] Install and test basic functionality

Generated with [Claude Code](https://claude.com/claude-code)